### PR TITLE
Session lifetime allows the full range of possible values

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ Usage:
   speculate env ROLENAME [flags]
 
 Flags:
-  -a, --account string   Account ID to assume role on (defaults to source account
-  -l, --lifetime int     Set lifetime of credentials in seconds (defaults to 3600 seconds / 1 hour, min 900, max 3600) (default 3600)
+  -a, --account string   Account ID to assume role on (defaults to source account)
+  -h, --help             help for env
+  -l, --lifetime int     Set lifetime of credentials in seconds between 900 and 43200 (default 3600)
   -m, --mfa              Use MFA when assuming role
       --mfacode string   Code to use for MFA
       --policy string    Set a IAM policy in JSON for the assumed credentials

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -93,9 +93,9 @@ var envCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(envCmd)
 	//revive:disable:line-length-limit
-	envCmd.Flags().StringP("account", "a", "", "Account ID to assume role on (defaults to source account")
+	envCmd.Flags().StringP("account", "a", "", "Account ID to assume role on (defaults to source account)")
 	envCmd.Flags().StringP("session", "s", "", "Set session name for assumed role (defaults to origin user name)")
-	envCmd.Flags().Int64P("lifetime", "l", 3600, "Set lifetime of credentials in seconds (defaults to 3600 seconds / 1 hour, min 900, max 3600)")
+	envCmd.Flags().Int64P("lifetime", "l", creds.SessionLifetimeDefault, fmt.Sprintf("Set lifetime of credentials in seconds between %d and %d", creds.SessionLifetimeMin, creds.SessionLifetimeMax))
 	envCmd.Flags().String("policy", "", "Set a IAM policy in JSON for the assumed credentials")
 	envCmd.Flags().BoolP("mfa", "m", false, "Use MFA when assuming role")
 	envCmd.Flags().String("mfacode", "", "Code to use for MFA")

--- a/creds/lifetime.go
+++ b/creds/lifetime.go
@@ -4,10 +4,21 @@ import (
 	"fmt"
 )
 
+// Constants for the session duration parameter in calls to sts:AssumeRole and
+// sts:GetSessionToken.
+const (
+	SessionLifetimeMin     = 900
+	SessionLifetimeMax     = 3600 * 12
+	SessionLifetimeDefault = 3600
+)
+
 func validateLifetime(lifetime int64) error {
 	logger.InfoMsgf("validating lifetime: %d", lifetime)
-	if lifetime != 0 && (lifetime < 900 || lifetime > 3600) {
-		return fmt.Errorf("lifetime must be between 900 and 3600: %d", lifetime)
+	if lifetime != 0 && (lifetime < SessionLifetimeMin || lifetime > SessionLifetimeMax) {
+		return fmt.Errorf("lifetime must be between %d and %d: %d",
+			SessionLifetimeMin,
+			SessionLifetimeMax,
+			lifetime)
 	}
 	return nil
 }


### PR DESCRIPTION
See https://docs.aws.amazon.com/STS/latest/APIReference/API_GetSessionToken.html

(edit: See also: https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html)

The command line default for session lifetime remains set to 3600 to
preserve original behavior.  The help text is cleaned up slightly to
avoid stuttering from repeating the default value and using two
parentheticals.