### PR TITLE
support different lifetimes for sessiontoken and assumerole

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,15 +41,15 @@ The env command accepts some options for controlling which account to assume a r
 
 ```
 # speculate env --help
-Print environment variables for an assumed role
+Generate temporary credentials, either by assuming a role or requesting a session token
 
 Usage:
-  speculate env ROLENAME [flags]
+  speculate env [ROLENAME] [flags]
 
 Flags:
   -a, --account string   Account ID to assume role on (defaults to source account)
   -h, --help             help for env
-  -l, --lifetime int     Set lifetime of credentials in seconds between 900 and 43200 (default 3600)
+  -l, --lifetime int     Set lifetime of credentials in seconds. For SessionToken, must be between 900 and 129600 (default 3600). For AssumeRole, must be between 900 and 43200 (default 3600)
   -m, --mfa              Use MFA when assuming role
       --mfacode string   Code to use for MFA
       --policy string    Set a IAM policy in JSON for the assumed credentials

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -85,8 +85,8 @@ func envRunner(cmd *cobra.Command, args []string) error {
 }
 
 var envCmd = &cobra.Command{
-	Use:   "env ROLENAME",
-	Short: "Print environment variables for an assumed role",
+	Use:   "env [ROLENAME]",
+	Short: "Generate temporary credentials, either by assuming a role or requesting a session token",
 	RunE:  envRunner,
 }
 
@@ -99,11 +99,13 @@ func init() {
 		"lifetime", "l",
 		0,
 		fmt.Sprintf(
-			"Set lifetime of credentials in seconds. For SessionToken, must be between %d and %d. For AssumeRole, must be between %d and %d",
+			"Set lifetime of credentials in seconds. For SessionToken, must be between %d and %d (default %d). For AssumeRole, must be between %d and %d (default %d)",
 			creds.SessionTokenLifetimeLimits.Min,
 			creds.SessionTokenLifetimeLimits.Max,
+			creds.SessionTokenLifetimeLimits.Default,
 			creds.AssumeRoleLifetimeLimits.Min,
 			creds.AssumeRoleLifetimeLimits.Max,
+			creds.AssumeRoleLifetimeLimits.Default,
 		),
 	)
 	envCmd.Flags().String("policy", "", "Set a IAM policy in JSON for the assumed credentials")

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -86,7 +86,7 @@ func envRunner(cmd *cobra.Command, args []string) error {
 
 var envCmd = &cobra.Command{
 	Use:   "env [ROLENAME]",
-	Short: "Generate temporary credentials, either by assuming a role or requesting a session token",
+	Short: "Generate temporary credentials by assuming a role or requesting a session token",
 	RunE:  envRunner,
 }
 

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -95,7 +95,17 @@ func init() {
 	//revive:disable:line-length-limit
 	envCmd.Flags().StringP("account", "a", "", "Account ID to assume role on (defaults to source account)")
 	envCmd.Flags().StringP("session", "s", "", "Set session name for assumed role (defaults to origin user name)")
-	envCmd.Flags().Int64P("lifetime", "l", creds.SessionLifetimeDefault, fmt.Sprintf("Set lifetime of credentials in seconds between %d and %d", creds.SessionLifetimeMin, creds.SessionLifetimeMax))
+	envCmd.Flags().Int64P(
+		"lifetime", "l",
+		0,
+		fmt.Sprintf(
+			"Set lifetime of credentials in seconds. For SessionToken, must be between %d and %d. For AssumeRole, must be between %d and %d",
+			creds.SessionTokenLifetimeLimits.Min,
+			creds.SessionTokenLifetimeLimits.Max,
+			creds.AssumeRoleLifetimeLimits.Min,
+			creds.AssumeRoleLifetimeLimits.Max,
+		),
+	)
 	envCmd.Flags().String("policy", "", "Set a IAM policy in JSON for the assumed credentials")
 	envCmd.Flags().BoolP("mfa", "m", false, "Use MFA when assuming role")
 	envCmd.Flags().String("mfacode", "", "Code to use for MFA")

--- a/creds/assumerole.go
+++ b/creds/assumerole.go
@@ -105,5 +105,6 @@ func (c Creds) assumeRolePreflight(options *AssumeRoleOptions) error {
 		}
 	}
 
-	return validateLifetime(options.Lifetime)
+	options.Lifetime, err = validateLifetime(options.Lifetime, AssumeRoleLifetimeLimits)
+	return err
 }

--- a/creds/getsessiontoken.go
+++ b/creds/getsessiontoken.go
@@ -14,10 +14,12 @@ type GetSessionTokenOptions struct {
 
 // GetSessionToken executes an AWS session token request
 func (c Creds) GetSessionToken(options GetSessionTokenOptions) (Creds, error) {
+	var err error
+
 	logger.InfoMsg("getting session token")
 	logger.DebugMsgf("getsessiontoken parameters: %+v", options)
 
-	err := validateLifetime(options.Lifetime)
+	options.Lifetime, err = validateLifetime(options.Lifetime, SessionTokenLifetimeLimits)
 	if err != nil {
 		return Creds{}, err
 	}

--- a/creds/lifetime.go
+++ b/creds/lifetime.go
@@ -4,21 +4,32 @@ import (
 	"fmt"
 )
 
-// Constants for the session duration parameter in calls to sts:AssumeRole and
-// sts:GetSessionToken.
-const (
-	SessionLifetimeMin     = 900
-	SessionLifetimeMax     = 3600 * 12
-	SessionLifetimeDefault = 3600
-)
+// LifetimeLimits describes the minimum, maximum, and default values for
+// credential lifespan
+type LifetimeLimits struct {
+	Min, Max, Default int64
+}
 
-func validateLifetime(lifetime int64) error {
+// SessionTokenLifetimeLimits describes the min, max, and default lifespan for
+// the sts:GetSessionToken call
+var SessionTokenLifetimeLimits = LifetimeLimits{Min: 900, Max: 3600 * 36, Default: 3600}
+
+// AssumeRoleLifetimeLimits describes the min, max, and default lifespan for
+// the sts:AssumeRole call
+var AssumeRoleLifetimeLimits = LifetimeLimits{Min: 900, Max: 3600 * 12, Default: 3600}
+
+func validateLifetime(l int64, limits LifetimeLimits) (int64, error) {
+	lifetime := l
 	logger.InfoMsgf("validating lifetime: %d", lifetime)
-	if lifetime != 0 && (lifetime < SessionLifetimeMin || lifetime > SessionLifetimeMax) {
-		return fmt.Errorf("lifetime must be between %d and %d: %d",
-			SessionLifetimeMin,
-			SessionLifetimeMax,
+	if lifetime == 0 {
+		logger.InfoMsgf("setting lifetime to default: %d", limits.Default)
+		lifetime = limits.Default
+	}
+	if lifetime != 0 && (lifetime < limits.Min || lifetime > limits.Max) {
+		return 0, fmt.Errorf("lifetime must be between %d and %d: %d",
+			limits.Min,
+			limits.Max,
 			lifetime)
 	}
-	return nil
+	return lifetime, nil
 }


### PR DESCRIPTION
@bmatsuo-at-luthersystems I think this expands on your PR and gets you the full 36-hour window for session tokens. Does it look sane to you?