### PR TITLE
Add AWS_REGION to envvar map

### DIFF
--- a/creds/export.go
+++ b/creds/export.go
@@ -26,7 +26,7 @@ var Translations = map[string]map[string]string{
 		"AWS_SESSION_TOKEN":     "SessionToken",
 		"AWS_SECURITY_TOKEN":    "SessionToken",
 		"AWS_DEFAULT_REGION":    "Region",
-		"AWS_REGION":    "Region",
+		"AWS_REGION":            "Region",
 	},
 	"console": {
 		"sessionId":    "AccessKey",

--- a/creds/export.go
+++ b/creds/export.go
@@ -26,6 +26,7 @@ var Translations = map[string]map[string]string{
 		"AWS_SESSION_TOKEN":     "SessionToken",
 		"AWS_SECURITY_TOKEN":    "SessionToken",
 		"AWS_DEFAULT_REGION":    "Region",
+		"AWS_REGION":    "Region",
 	},
 	"console": {
 		"sessionId":    "AccessKey",


### PR DESCRIPTION
Adds the `AWS_REGION` environmental variable to the `envvar` map. AWS SDK inconsistently handles the region variable. For [example](https://github.com/aws/aws-sdk-go/issues/2103), the Go SDK by default looks for `AWS_REGION` instead of `AWS_DEFAULT_REGION`.